### PR TITLE
Add auto-contrast, text outlines, and larger subclock text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A lightweight Wayland layer-shell desktop clock widget written in Rust. Renders 
 - **Up to 2 timezone sub-clocks** displayed beneath the primary clock
 - **Battery indicator** with colour-coded charge level and charging animation
 - **Custom background images** for both digital and analogue faces (PNG/JPEG)
+- **Auto-contrast** -- text colour adapts to background brightness when using gallery images
+- **Text outlines** -- contrasting outline around all text for readability on any background
 - **Full theming** -- foreground, background, hand colours, tick marks, all in hex RGBA
 - **Drag-to-move** with cross-monitor support
 - **IPC control** via Unix socket (`clockiectl`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,18 @@ All colours are specified in `RRGGBB` or `RRGGBBAA` hex format. The `#` prefix i
 | `minute_hand_color` | hex string | `"FFFFFFFF"` | Analogue minute hand colour |
 | `second_hand_color` | hex string | `"ef4444FF"` | Analogue second hand colour |
 | `tick_color` | hex string | `"CCCCCCFF"` | Tick mark colour on procedural analogue face |
+| `text_outline` | boolean | `true` | Draw a contrasting outline around all text for readability |
+| `auto_contrast` | string | `"auto"` | Auto-contrast mode: `"auto"`, `"always"`, or `"never"` |
+
+**Auto-contrast** automatically picks a light or dark text colour based on the background brightness. This is especially useful when gallery images cycle through backgrounds of varying brightness.
+
+- `"auto"` -- activates only when a gallery is configured (digital or analogue)
+- `"always"` -- always samples the background and adapts text colour, even with a single static image
+- `"never"` -- always uses the configured `fg_color`
+
+When auto-contrast determines the background is light (luminance > 140), it switches to dark text (`#1a1a1a`). Otherwise it uses the configured `fg_color`.
+
+**Text outline** draws all text at 8 compass offsets in a contrasting colour (dark outline for light text, light for dark), then the actual text on top. The outline radius scales with font size. This ensures text remains readable regardless of the background. Set `text_outline = false` to disable.
 
 ## [background]
 
@@ -140,6 +152,8 @@ fg_color          = "FFFFFFFF"
 bg_color          = "1a1a2eCC"
 second_hand_color = "ef4444FF"
 tick_color        = "CCCCCCFF"
+text_outline      = true
+auto_contrast     = "auto"
 
 [background]
 digital_image       = ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,13 @@ pub struct ThemeConfig {
     pub second_hand_color: [u8; 4],
     #[serde(default = "default_tick_color", deserialize_with = "deserialize_color")]
     pub tick_color: [u8; 4],
+    /// Draw a contrasting outline around all text for readability
+    #[serde(default = "default_true")]
+    pub text_outline: bool,
+    /// Auto-contrast mode: "auto" | "always" | "never"
+    /// "auto" activates when a gallery is configured, "always" always samples background
+    #[serde(default = "default_auto_contrast")]
+    pub auto_contrast: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -210,6 +217,7 @@ fn default_font_size() -> f32 { 48.0 }
 fn default_diameter() -> u32 { 180 }
 fn default_image_scale() -> String { "fill".into() }
 
+fn default_auto_contrast() -> String { "auto".into() }
 fn default_fg_color() -> [u8; 4] { [0xFF, 0xFF, 0xFF, 0xFF] }
 fn default_bg_color() -> [u8; 4] { [0x00, 0x00, 0x00, 0xCC] }
 fn default_second_hand_color() -> [u8; 4] { [0xFF, 0x44, 0x44, 0xFF] }
@@ -294,6 +302,8 @@ impl Default for ThemeConfig {
             minute_hand_color: default_fg_color(),
             second_hand_color: default_second_hand_color(),
             tick_color: default_tick_color(),
+            text_outline: true,
+            auto_contrast: default_auto_contrast(),
         }
     }
 }
@@ -489,6 +499,10 @@ minute_hand_color = "FFFFFFFF"
 second_hand_color = "ef4444FF"
 # Tick mark colour (used when no face image)
 tick_color        = "CCCCCCFF"
+# Draw a contrasting outline around all text for readability
+text_outline      = true
+# Auto-contrast: "auto" (active when gallery configured) | "always" | "never"
+auto_contrast     = "auto"
 
 [background]
 # Path to a PNG/JPEG behind the digital clock text (empty = bg_color fill)

--- a/src/renderer/battery.rs
+++ b/src/renderer/battery.rs
@@ -1,7 +1,7 @@
 use crate::battery::BatteryInfo;
 use crate::canvas::{Canvas, FontState};
 use crate::config::FaceMode;
-use crate::renderer::ClockState;
+use crate::renderer::{ClockState, draw_contrast_text};
 
 pub fn render(canvas: &mut Canvas, state: &ClockState, font: &FontState, battery: &BatteryInfo) {
     let w = canvas.width() as f32;
@@ -32,7 +32,8 @@ pub fn render(canvas: &mut Canvas, state: &ClockState, font: &FontState, battery
         [0xEF, 0x44, 0x44, 0xFF] // red
     };
 
-    let outline_color: [u8; 4] = [0xCC, 0xCC, 0xCC, 0xFF];
+    let tc = state.contrast.text_color;
+    let outline_color: [u8; 4] = [tc[0], tc[1], tc[2], 0xCC];
 
     // Draw battery outline
     canvas.draw_line(x, y, x + icon_w, y, outline_color, border);
@@ -77,7 +78,7 @@ pub fn render(canvas: &mut Canvas, state: &ClockState, font: &FontState, battery
         let (tw, _th) = font.measure_text(&text, font_size);
         let text_x = x - tw - margin * 0.4;
         let text_y = y + (icon_h - font_size) / 2.0;
-        let text_color = state.config.theme.fg_color;
-        font.draw_text(canvas, &text, text_x, text_y, font_size, text_color);
+        let text_color = state.contrast.text_color;
+        draw_contrast_text(font, canvas, &text, text_x, text_y, font_size, text_color, &state.contrast);
     }
 }

--- a/src/renderer/subclock.rs
+++ b/src/renderer/subclock.rs
@@ -1,13 +1,12 @@
 use crate::canvas::{Canvas, FontState};
 use crate::config::FaceMode;
-use crate::renderer::ClockState;
+use crate::renderer::{ClockState, SubclockSizing, draw_contrast_text};
 use crate::time_utils;
 
 pub fn render(canvas: &mut Canvas, state: &ClockState, font: &FontState) {
     let w = canvas.width() as f32;
     let h = canvas.height() as f32;
     let config = &state.config;
-    let theme = &config.theme;
 
     let timezones: Vec<_> = config.timezone.iter().take(2).collect();
     if timezones.is_empty() { return; }
@@ -21,24 +20,20 @@ pub fn render(canvas: &mut Canvas, state: &ClockState, font: &FontState) {
         FaceMode::Analogue => config.clock.diameter as f32 * 0.25,
     };
 
-    let pad_y = base * 0.25;
-    let sc_label_size = base * 0.22;
-    let sc_time_size = sc_label_size * 1.3;
-    let sc_row_h = sc_label_size + sc_time_size + sc_label_size * 0.1;
-    let sc_sep_gap = pad_y * 0.5;
-    let tz_area_h = sc_sep_gap + sc_row_h + sc_sep_gap;
-    let tz_y_start = h - tz_area_h;
+    let sz = SubclockSizing::from_base(base);
+    let tz_y_start = h - sz.area_h;
 
     // Draw separator line
-    let sep_color = [theme.fg_color[0], theme.fg_color[1], theme.fg_color[2], 0x66];
+    let tc = state.contrast.text_color;
+    let sep_color = [tc[0], tc[1], tc[2], 0x66];
     canvas.draw_line(w * 0.05, tz_y_start, w * 0.95, tz_y_start, sep_color, 1.0);
 
     let tz_count = timezones.len();
     let col_w = w / tz_count as f32;
 
     // Vertically centre the label+time block within the tz area
-    let content_h = sc_label_size + sc_time_size;
-    let y_offset = tz_y_start + (tz_area_h - content_h) / 2.0;
+    let content_h = sz.label_size + sz.time_size;
+    let y_offset = tz_y_start + (sz.area_h - content_h) / 2.0;
 
     for (i, tz) in timezones.iter().enumerate() {
         let col_cx = col_w * i as f32 + col_w / 2.0;
@@ -49,15 +44,15 @@ pub fn render(canvas: &mut Canvas, state: &ClockState, font: &FontState) {
             config.clock.show_seconds,
         ).unwrap_or_else(|| "??:??".into());
 
-        let label_color = [theme.fg_color[0], theme.fg_color[1], theme.fg_color[2], 0xAA];
+        let label_color = [tc[0], tc[1], tc[2], 0xAA];
 
-        let (lw, _) = font.measure_text(&tz.label, sc_label_size);
+        let (lw, _) = font.measure_text(&tz.label, sz.label_size);
         let label_x = col_cx - lw / 2.0;
-        font.draw_text(canvas, &tz.label, label_x, y_offset, sc_label_size, label_color);
+        draw_contrast_text(font, canvas, &tz.label, label_x, y_offset, sz.label_size, label_color, &state.contrast);
 
-        let (tw, _) = font.measure_text(&time_str, sc_time_size);
+        let (tw, _) = font.measure_text(&time_str, sz.time_size);
         let time_x = col_cx - tw / 2.0;
-        let time_y = y_offset + sc_label_size * 1.1;
-        font.draw_text(canvas, &time_str, time_x, time_y, sc_time_size, theme.fg_color);
+        let time_y = y_offset + sz.label_size * 1.1;
+        draw_contrast_text(font, canvas, &time_str, time_x, time_y, sz.time_size, state.contrast.text_color, &state.contrast);
     }
 }


### PR DESCRIPTION
## Summary
- Larger subclock text via shared `SubclockSizing` struct (label 0.33x base, time 1.5x label) — roughly 50% bigger than before
- Auto-contrast: text colour adapts to background brightness when gallery images rotate, configurable via `auto_contrast = "auto" | "always" | "never"`
- Text outlines: contrasting outline drawn around all text for readability on any background, configurable via `text_outline = true | false`
- Rendering split into background/foreground phases with luminance sampling in between

## Test plan
- [x] `cargo build` compiles cleanly
- [x] Run with no gallery: subclock text visibly larger, text outline visible
- [x] Run with gallery: text colour adapts when background changes (light bg → dark text)
- [ ] `text_outline = false` disables outlines
- [x] `auto_contrast = "never"` uses static `fg_color`
- [ ] Both digital and analogue modes work correctly